### PR TITLE
docs: add Troubleshooting section for js-brasil CommonJS compile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,41 @@ const formatted = new NgBrDirectives.InscricaoEstadualPipe()
   .transform('625085487072', 'sp');
 ```
 
+## Troubleshooting
+
+### `js-brasil` fails to compile / CommonJS warning in Angular 11+
+
+Angular 11 introduced stricter handling of CommonJS dependencies. Because `js-brasil` ships
+a CommonJS build, Angular may print a warning or fail with an error like:
+
+```
+WARNING in js-brasil (and its dependencies) should be converted to ES modules.
+CommonJS or AMD dependencies can cause optimization bailouts.
+```
+
+**Fix:** add `js-brasil` to `allowedCommonJsDependencies` in your project's `angular.json`:
+
+```json
+{
+  "projects": {
+    "<your-app>": {
+      "architect": {
+        "build": {
+          "options": {
+            "allowedCommonJsDependencies": ["js-brasil"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+See the [Angular CommonJS dependencies guide](https://angular.io/guide/build#configuring-commonjs-dependencies)
+for more details.
+
+---
+
 ## Collaborate
 
 ```bash


### PR DESCRIPTION
Closes #77

## Problem

`js-brasil` ships a CommonJS build. Angular 11 introduced stricter handling of CommonJS dependencies — by default it emits a warning, and projects with `"budgets"` or strict build settings may treat it as an error:

```
WARNING in js-brasil (and its dependencies) should be converted to ES modules.
CommonJS or AMD dependencies can cause optimization bailouts.
```

This causes `npm start` / `ng build` to fail for users who haven't opted-in CommonJS deps explicitly.

## Root cause

`js-brasil`'s `tsconfig.json` targets `"module": "commonjs"` (implicit, ES5 output) with no separate ESM build or `"module"` field in `package.json`. Angular's webpack build (Ivy, Angular 11+) flags this.

## Fix in this PR (immediate)

Add a **Troubleshooting** section to the README with the one-liner `allowedCommonJsDependencies` fix users can apply to their own `angular.json`.

## Long-term fix (out of scope, tracked separately)

The proper fix is for `js-brasil` to ship a parallel ESM build:

1. Add a `rollup.config.js` to `js-brasil` that produces `dist/esm/index.js`
2. Add a `"module": "dist/esm/index.js"` field to `js-brasil/package.json`
3. Update `ng-brazil` (and its `angular.json`) to reference the ESM entry point

Angular's webpack will then pick up the ESM build automatically via the `"module"` field and stop flagging it. Until that's done in `js-brasil`, users need the `allowedCommonJsDependencies` workaround documented here.

## Test plan

- [ ] Read the new Troubleshooting section in the README
- [ ] Apply the `allowedCommonJsDependencies` snippet to an Angular 11+ project that previously failed — confirm `ng build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)