### PR TITLE
fix: upgrade js-brasil to 2.7.1 (fixes currency mask #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,41 @@ const formatted = new NgBrDirectives.InscricaoEstadualPipe()
   .transform('625085487072', 'sp');
 ```
 
+## Troubleshooting
+
+### `js-brasil` fails to compile / CommonJS warning in Angular 11+
+
+Angular 11 introduced stricter handling of CommonJS dependencies. Because `js-brasil` ships
+a CommonJS build, Angular may print a warning or fail with an error like:
+
+```
+WARNING in js-brasil (and its dependencies) should be converted to ES modules.
+CommonJS or AMD dependencies can cause optimization bailouts.
+```
+
+**Fix:** add `js-brasil` to `allowedCommonJsDependencies` in your project's `angular.json`:
+
+```json
+{
+  "projects": {
+    "<your-app>": {
+      "architect": {
+        "build": {
+          "options": {
+            "allowedCommonJsDependencies": ["js-brasil"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+See the [Angular CommonJS dependencies guide](https://angular.io/guide/build#configuring-commonjs-dependencies)
+for more details.
+
+---
+
 ## Collaborate
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@angular/router": "^19.2.0",
     "autoprefixer": "^10.2.3",
     "core-js": "^3.6.4",
-    "js-brasil": "2.5.3",
+    "js-brasil": "2.7.1",
     "postcss": "^8.2.4",
     "rxjs": "^7.8.0",
     "rxjs-compat": "^6.0.0",


### PR DESCRIPTION
Upgrades `js-brasil` from `2.5.3` → `2.7.1`.

## Why

Fixes #66 — `MASKS.currency.textMask` now always includes two decimal positions in the mask, so users see `R$ 100,__` instead of `R$ 100` with no decimal at all.

## What changed in js-brasil 2.7.1

- `MASKS.currency.textMask` wraps an integer-only `createNumberMask` and always appends `,\d\d` to every returned mask — making the decimal separator and two digits required, non-optional positions
- `text-mask-addons` runtime dependency removed (inlined into js-brasil)

## Dependency chain

1. mariohmol/js-brasil#91 — the fix
2. mariohmol/js-brasil#92 — version bump to 2.7.1 *(merge and publish before merging this PR)*
3. **This PR** — consumes 2.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)